### PR TITLE
Potential fix for code scanning alert no. 54: Clear-text logging of sensitive information

### DIFF
--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -127,8 +127,6 @@ const loginUser = asyncHandler(async (req, res) => {
     throw new ApiError(404, "User does not exist");
   }
   console.log("User found: ", user);
-  console.log("Password to compare: ", password);
-  console.log("Stored hashed password: ", user.password);
 
     const isPasswordCorrect = await user.isPasswordValid(password);
   


### PR DESCRIPTION
Potential fix for [https://github.com/Harsh-Mathur-1503/backend-proffesional/security/code-scanning/54](https://github.com/Harsh-Mathur-1503/backend-proffesional/security/code-scanning/54)

To fix this problem, we should remove all logging of sensitive information, specifically the user's password (stored or entered as input). In `src/controllers/user.controller.js`, on lines 130 and 131, both `console.log("Password to compare: ", password);` and `console.log("Stored hashed password: ", user.password);` must be deleted. If password debugging is ever necessary, developers should use mock accounts and avoid using real credentials, and even then, take care to never log them. No replacements or obfuscation are needed; just remove these statements from the code to prevent accidental leakage.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
