### PR TITLE
Potential fix for code scanning alert no. 52: Database query built from user-controlled sources

### DIFF
--- a/src/controllers/video.controller.js
+++ b/src/controllers/video.controller.js
@@ -127,6 +127,9 @@ const updateVideo = asyncHandler(async (req, res) => {
   if (!title || !description) {
     throw new ApiError(400, "Title and description are required");
   }
+  if (typeof title !== "string" || typeof description !== "string") {
+    throw new ApiError(400, "Title and description must be strings");
+  }
 
   try {
     const oldFoundVideo = await Video.findById(videoId);
@@ -136,7 +139,7 @@ const updateVideo = asyncHandler(async (req, res) => {
 
     const updatedVideo = await Video.findByIdAndUpdate(
       videoId,
-      { title, description },
+      { $set: { title, description } },
       { new: true }
     );
 


### PR DESCRIPTION
Potential fix for [https://github.com/Harsh-Mathur-1503/backend-proffesional/security/code-scanning/52](https://github.com/Harsh-Mathur-1503/backend-proffesional/security/code-scanning/52)

To fix the problem, we must ensure that the user can only update the `title` and `description` fields with literal string values. The best fix is to validate that both `title` and `description` are strings before using them in the query, and then update the document with those fields, using the `$set` operator to allow only these fields to be updated. This is the safest approach and does not change existing functionality for legitimate string inputs. To do this, add type checks immediately after extracting `title` and `description` from `req.body`, and before calling `findByIdAndUpdate`. If either is not a string, return a 400 error. When calling `findByIdAndUpdate`, use `{ $set: { title, description } }` as the update object. All changes are to be made within the `updateVideo` function in `src/controllers/video.controller.js`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
