### PR TITLE
Potential fix for code scanning alert no. 40: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.9.5",
     "mongoose-aggregate-paginate-v2": "^1.0.7",
-    "multer": "^2.0.2"
+    "multer": "^2.0.2",
+    "express-rate-limit": "^8.0.1"
   }
 }

--- a/src/routes/user.routes.js
+++ b/src/routes/user.routes.js
@@ -1,3 +1,4 @@
+import rateLimit from "express-rate-limit";
 import { Router } from "express";
 import {
   getCurrentUser,
@@ -16,6 +17,13 @@ import { upload } from "../middlewares/multer.middleware.js";
 import { verifyJWT } from "../middlewares/auth.middleware.js";
 const router = Router();
 
+// Rate limiter for sensitive endpoints (e.g., history)
+const historyRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // 100 requests per window per IP
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 router.route("/register").post(
   upload.fields([
     {
@@ -53,6 +61,6 @@ router
 
 router.route("/c/:username").get(getUserChannelProfile);
 
-router.route("/history").get(verifyJWT, getWatchHistory);
+router.route("/history").get(historyRateLimiter, verifyJWT, getWatchHistory);
 
 export default router;


### PR DESCRIPTION
Potential fix for [https://github.com/Harsh-Mathur-1503/backend-proffesional/security/code-scanning/40](https://github.com/Harsh-Mathur-1503/backend-proffesional/security/code-scanning/40)

To fix the issue, we should add a rate-limiting middleware to the `/history` (`getWatchHistory`) route. The recommended way is to use the well-established `express-rate-limit` package, as suggested. This middleware should be required and instantiated with suitable thresholds (e.g., 100 requests per 15 minutes from a single IP) to avoid accidental denial of service while allowing legitimate traffic. Place the rate limiter specifically on the `/history` route, so that only calls to this endpoint are affected. To implement this, we need to:

- Import `express-rate-limit` at the top of the file.
- Create a rate limiter instance with appropriate settings just before routes are defined.
- Insert the rate limiter as middleware to the `/history` GET route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
