### PR TITLE
Potential fix for code scanning alert no. 50: Database query built from user-controlled sources

### DIFF
--- a/src/controllers/playlist.controller.js
+++ b/src/controllers/playlist.controller.js
@@ -192,17 +192,17 @@ const updatePlaylist = asyncHandler(async (req, res) => {
   if (!playlistId) {
     throw new ApiError(400, "Playlist id is required");
   }
-  if (!name) {
-    throw new ApiError(400, "Name is required");
+  if (typeof name !== "string" || !name) {
+    throw new ApiError(400, "Valid name is required");
   }
-  if (!description) {
-    throw new ApiError(400, "Description is required");
+  if (typeof description !== "string" || !description) {
+    throw new ApiError(400, "Valid description is required");
   }
 
   try {
     const updatedPlaylist = await Playlist.findByIdAndUpdate(
       playlistId,
-      { name, description },
+      { $set: { name, description } },
       { new: true }
     );
 


### PR DESCRIPTION
Potential fix for [https://github.com/Harsh-Mathur-1503/backend-proffesional/security/code-scanning/50](https://github.com/Harsh-Mathur-1503/backend-proffesional/security/code-scanning/50)

To fix this, ensure that both `name` and `description` are always used as *literal values* rather than as possible sub-query objects or operators. There are two standard ways:
- **Input validation:** Check that both are strings and not objects before using them in a query.
- **Use of `$set` operator:** In `findByIdAndUpdate`, always wrap updates that use user input inside a `$set` object to ensure they're assigned as values, not interpreted as part of an operator-injection attack.
- **Optionally**, enforce `$eq` on the filter, although here the main concern is the update document rather than the filter.

For best safety and clarity, validate that `name` and `description` are strings before use, and update `{ $set: { name, description } }` in the update query for the playlist update route.

**Implementation steps within `src/controllers/playlist.controller.js` in the `updatePlaylist` handler, lines around 188-222:**
1. Add type checks for `name` and `description` to confirm they're strings.
2. Change the update document in `findByIdAndUpdate` from `{ name, description }` to `{ $set: { name, description }}`.

No additional imports are needed, as all necessary utilities are present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
