### PR TITLE
Potential fix for code scanning alert no. 48: Database query built from user-controlled sources

### DIFF
--- a/src/controllers/like.controller.js
+++ b/src/controllers/like.controller.js
@@ -114,9 +114,9 @@ const toggleTweetLike = asyncHandler(async (req, res) => {
         .status(201)
         .json(new ApiResponse(201, "Tweet Liked successfully", savedTweetLike));
     } else {
-      const deletedTweetLike = await Like.findByIdAndDelete({
-        tweet: tweetId,
-        user: userId,
+      const deletedTweetLike = await Like.findOneAndDelete({
+        tweet: { $eq: tweetId },
+        user: { $eq: userId },
       });
       if (!deletedTweetLike) {
         throw new ApiError(500, "Your like was not removed");


### PR DESCRIPTION
Potential fix for [https://github.com/Harsh-Mathur-1503/backend-proffesional/security/code-scanning/48](https://github.com/Harsh-Mathur-1503/backend-proffesional/security/code-scanning/48)

Use a query that forces literal comparison for untrusted values, and use the correct Mongoose method for deleting by compound criteria.

Best fix in this file:
- In `toggleTweetLike` (around lines 117–120), replace `Like.findByIdAndDelete({...})` with `Like.findOneAndDelete({...})` because the filter contains `tweet` and `user` (not `_id`).
- Wrap both `tweetId` and `userId` in `$eq` in that delete filter to ensure they are treated as literal values, not query operators.
- This keeps behavior the same (delete the existing like for this tweet/user pair) while resolving the injection pattern and API misuse.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
