### PR TITLE
Potential fix for code scanning alert no. 39: Missing rate limiting

### DIFF
--- a/src/routes/user.routes.js
+++ b/src/routes/user.routes.js
@@ -24,6 +24,14 @@ const historyRateLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
 });
+
+// Rate limiter for media update endpoints (avatar/cover image)
+const mediaUpdateRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 20, // limit repeated expensive upload/db operations per IP
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 router.route("/register").post(
   upload.fields([
     {
@@ -57,7 +65,12 @@ router
 
 router
   .route("/cover-image")
-  .patch(verifyJWT, upload.single("coverImage"), updateCoverImage);
+  .patch(
+    mediaUpdateRateLimiter,
+    verifyJWT,
+    upload.single("coverImage"),
+    updateCoverImage
+  );
 
 router.route("/c/:username").get(getUserChannelProfile);
 


### PR DESCRIPTION
Potential fix for [https://github.com/Harsh-Mathur-1503/backend-proffesional/security/code-scanning/39](https://github.com/Harsh-Mathur-1503/backend-proffesional/security/code-scanning/39)

Add a dedicated rate-limiting middleware for media update endpoints and place it before `verifyJWT`/upload/controller in the `/cover-image` route chain.

Best single fix in this file:
- In `src/routes/user.routes.js`, define a new limiter (for example `mediaUpdateRateLimiter`) near the existing `historyRateLimiter`.
- Apply it to the `PATCH /cover-image` route so requests are throttled before expensive upload/database operations.
- Keep existing middleware order/functionality intact, only inserting the limiter.

No new imports are required since `rateLimit` is already imported from `express-rate-limit`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
